### PR TITLE
Derive stylesheet theme directory from Theme enum

### DIFF
--- a/qfluentwidgets/common/style_sheet.cpp
+++ b/qfluentwidgets/common/style_sheet.cpp
@@ -155,9 +155,19 @@ QString getStyleSheet(QVariant *source, Theme theme = Theme::AUTO) //这个函�
     if(source->canConvert<QString>()){
         //qDebug() << source->value<QString>();
 
-        //TODO:这个地方需要实现根据自动获取系统Theme
-        
-        QString path = "qfluentwidgets/qss/" + ThemeOptionsMap.value("LIGHT") + "/" + source->value<QString>() + ".qss";
+        Theme resolvedTheme = theme;
+        if(resolvedTheme == Theme::AUTO){
+            resolvedTheme = qconfig->getTheme();
+        }
+
+        QString themeOptionsName = "LIGHT";
+        if(resolvedTheme == Theme::DARK){
+            themeOptionsName = "DARK";
+        }else if(resolvedTheme == Theme::LIGHT){
+            themeOptionsName = "LIGHT";
+        }
+
+        QString path = "qfluentwidgets/qss/" + ThemeOptionsMap.value(themeOptionsName, ThemeOptionsMap.value("LIGHT")) + "/" + source->value<QString>() + ".qss";
         //qDebug() << path;
         StyleSheetFile *f = new StyleSheetFile(path);
         s = f;


### PR DESCRIPTION
## Summary
- resolve stylesheet paths using the requested theme instead of always selecting the light directory
- fall back to the configured theme for Theme::AUTO and translate it via the existing ThemeOptionsMap

## Testing
- cmake -S . -B build *(fails: repository does not provide a CMakeLists.txt at project root)*

------
https://chatgpt.com/codex/tasks/task_e_68dc9dd60eb0832c82f0d8198d608d39